### PR TITLE
macOS 以外の OS でも拡張をインストールできるようにする

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -32,15 +32,9 @@
   },
   "commands": {
     "go_to_next": {
-      "suggested_key": {
-        "mac": "Ctrl+MacCtrl+Right"
-      },
       "description": "go to next item"
     },
     "go_to_previous": {
-      "suggested_key": {
-        "mac": "Ctrl+MacCtrl+Left"
-      },
       "description": "go to previous item"
     }
   },


### PR DESCRIPTION
# 問題

Chrome Web Store から拡張をインストールしようとすると，次のようなエラーメッセージが表示されてインストールできません．
![image](https://user-images.githubusercontent.com/16241822/78956348-f9e42280-7b1c-11ea-9f6a-8e12a0dcaeff.png)

> An error has occurred
> There was a problem with the download. Please contact the developer or try again later.
> Invalid manifest

- インストール環境
  - Windows 10 Pro
  - Google Chrome Version 81.0.4044.92 (Official Build) (64-bit)


# 原因

Chrome の拡張設定から開発者モードで直接インストールを試みると，manifest ファイルのショートカットキーに `windows` または `default` 設定が存在しないためエラーになっていることが分かります．

![image](https://user-images.githubusercontent.com/16241822/78956476-64955e00-7b1d-11ea-8be7-e9ecfe3d8899.png)

> Failed to load extension
> Error
> Could not find key specification for 'command[1].suggested_key': Either specify a key for 'windows', or specify a default key.
> Could not load manifest.


# 解決

解決手段は次の2通りかと思います：
1. 上記エラーメッセージ通りに `windows` または `default` （あるいは両方とも）設定を追加する
2. `suggested_key` 自体を削除する

1 の場合：
- PROS
  - 問題が解決され，使い心地を維持できる
- CONS
  - Windows 以外の OS についてもケアをした方が良いが，動作確認のしづらい OS (e.g. Chrome OS) がありメンテナンスが難しい

2 の場合：
- PROS
  - OS ごとのケアを行う必要がなくなる
  - 後方互換性が維持できる
    - 現在のバージョンをインストールしている場合は `suggested_key` を削除してもキーの設定は残ったままとなり，アップデートによって使い心地が変わってしまうことがない 😌
  - `suggested_key` を削除しても，[ReadMe](https://github.com/doiken/QiitaZapping#2-%E3%83%9A%E3%83%BC%E3%82%B8%E4%B8%A1%E7%AB%AF%E3%81%AE%E3%82%A2%E3%83%AD%E3%83%BC%E6%8A%BC%E4%B8%8B%E3%82%82%E3%81%97%E3%81%8F%E3%81%AF%E3%82%B7%E3%83%A7%E3%83%BC%E3%83%88%E3%82%AB%E3%83%83%E3%83%88%E3%81%A7%E3%83%9A%E3%83%BC%E3%82%B8%E9%81%B7%E7%A7%BB%E9%96%8B%E5%A7%8B) に書かれているとおりの方法で，今後もショートカットキーを設定・利用することが可能
- CONS
  - 今後新規にインストールする場合は [ReadMe](https://github.com/doiken/QiitaZapping#2-%E3%83%9A%E3%83%BC%E3%82%B8%E4%B8%A1%E7%AB%AF%E3%81%AE%E3%82%A2%E3%83%AD%E3%83%BC%E6%8A%BC%E4%B8%8B%E3%82%82%E3%81%97%E3%81%8F%E3%81%AF%E3%82%B7%E3%83%A7%E3%83%BC%E3%83%88%E3%82%AB%E3%83%83%E3%83%88%E3%81%A7%E3%83%9A%E3%83%BC%E3%82%B8%E9%81%B7%E7%A7%BB%E9%96%8B%E5%A7%8B) の方法でユーザーが明示的に設定を行う必要がある

以上のことから，総合的には **2** の方法が良いと思いますので，その方針で修正しています．

# 動作確認

冒頭のインストール環境にて，次の点を確認しました：
- 修正後の拡張が開発者モードでインストールできること
- 設定後の拡張が qiita 上で動作すること
- ショートカットキーを独自に設定して使用できること


# 備考

Approve & マージしていただいた後に Chrome Web Store もアップデートする必要がありますが，その作業は owner @doiken にお願いいたします．