### PR TITLE
Adjust left position to prevent element overlap

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "QiitaZapping",
   "description": "Support zapping Qiita items by querying Qiita API",
-  "version": "0.5",
+  "version": "0.7",
   "action": {
     "default_icon": "icon_32.png",
     "default_popup": "popup.html"

--- a/public/style.css
+++ b/public/style.css
@@ -50,5 +50,5 @@
 	right: 0px;
 }
 ._QZ_center_left{
-	left:  0px;
+	left:  70px;
 }


### PR DESCRIPTION
## Changes

Changed left position from 0 to 70.  

With this change, the element behaves as follows based on the nav display mode:  
- **Compact**: Positioned next to the nav.  
- **Full**: Hidden behind the nav. 

<img width="600px" alt="image" src="https://github.com/user-attachments/assets/8cdcddd6-1a66-48da-a29b-fd3561727ade" />

<img width="600px" alf="image" src="https://github.com/user-attachments/assets/b79632f4-5f8d-45a1-8f70-4474aaeee03e" />
